### PR TITLE
Filter for "Create New Shortcut" dialog

### DIFF
--- a/main/Forms/frmGroup.cs
+++ b/main/Forms/frmGroup.cs
@@ -180,7 +180,7 @@ namespace client.Forms
                 CheckPathExists = true,
                 Multiselect = true,
                 DefaultExt = "exe",
-                Filter = "Exe or Shortcut (.exe, .lnk)|*.exe;*.lnk;*.url",
+                Filter = "Executable or Shortcut|*.exe;*.lnk;*.url;*.bat|All files (*.*)|*.*",
                 RestoreDirectory = true,
                 ReadOnlyChecked = true,
                 DereferenceLinks = false


### PR DESCRIPTION
Why limit the selection superficially when all files are supported and you can bypass the filter with pasting a direct path?

Default filter changed so that it also allow ".bat" and additional filter that allows any extension