### PR TITLE
Improvements

### DIFF
--- a/backgroundClient/Classes/Jumplist.cs
+++ b/backgroundClient/Classes/Jumplist.cs
@@ -39,9 +39,13 @@ namespace backgroundClient.Classes
                 userTaskbarCategory.AddJumpListItems(openAllShortcuts);
             }
 
-            list.AddCustomCategories(userTaskbarCategory);
+            try
+            {
+                list.AddCustomCategories(userTaskbarCategory);
 
-            list.Refresh();
+                list.Refresh();
+            }
+            catch { }
         }
     }
 }

--- a/backgroundClient/Classes/LoadedCategory.cs
+++ b/backgroundClient/Classes/LoadedCategory.cs
@@ -13,7 +13,7 @@ namespace backgroundClient.Classes
         public List<Image> programImages = new List<Image>();
         public List<ProgramShortcut> programShortcuts = new List<ProgramShortcut>();
 
-        public bool allowOpenAll = false;
+        public bool allowOpenAll;
         public int Width;
         public double Opacity = 10;
         public string ColorString = System.Drawing.ColorTranslator.ToHtml(Color.FromArgb(31, 31, 31));
@@ -31,8 +31,9 @@ namespace backgroundClient.Classes
             Width = newCat.Width;
             ColorString = newCat.ColorString;
             Name = newCat.Name;
-            
-            foreach(ProgramShortcut psc in programShortcuts)
+            allowOpenAll = newCat.allowOpenAll;
+
+            foreach (ProgramShortcut psc in programShortcuts)
             {
                 programImages.Add(newCat.loadImageCache(psc));
             }

--- a/backgroundClient/Classes/LoadedCategory.cs
+++ b/backgroundClient/Classes/LoadedCategory.cs
@@ -15,7 +15,7 @@ namespace backgroundClient.Classes
 
         public bool allowOpenAll;
         public int Width;
-        public double Opacity = 10;
+        public double Opacity;
         public string ColorString = System.Drawing.ColorTranslator.ToHtml(Color.FromArgb(31, 31, 31));
         public Icon groupIco;
         public string Name;
@@ -32,6 +32,7 @@ namespace backgroundClient.Classes
             ColorString = newCat.ColorString;
             Name = newCat.Name;
             allowOpenAll = newCat.allowOpenAll;
+            Opacity = newCat.Opacity;
 
             foreach (ProgramShortcut psc in programShortcuts)
             {

--- a/backgroundClient/Classes/Settings.cs
+++ b/backgroundClient/Classes/Settings.cs
@@ -29,6 +29,7 @@ namespace backgroundClient.Classes
             }
             else
             {
+                Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appDataRelative));
                 settingInfo = new Setting();
                 writeXML();
                 return;

--- a/backgroundClient/backgroundClient.csproj
+++ b/backgroundClient/backgroundClient.csproj
@@ -43,7 +43,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\AppData\Local\Jack Schierbeck\taskbar-groups\</OutputPath>
+    <OutputPath>..\main\Resources\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/main/Classes/Paths.cs
+++ b/main/Classes/Paths.cs
@@ -104,6 +104,8 @@ namespace client.Classes
 
         private static string setupBackgroundApplication()
         {
+            Directory.CreateDirectory(Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppDataRelativePath));
+
             string filePath;
             defaultBackgroundPath = Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppDataRelativePath, "Taskbar Groups Background.exe");
 

--- a/main/Classes/Paths.cs
+++ b/main/Classes/Paths.cs
@@ -13,16 +13,16 @@ namespace client.Classes
     static class Paths
     {
         /// <summary>
-        /// The folder in which the main executable resides.
-        /// </summary>
-        public static String path = System.IO.Path.GetDirectoryName(exeString);
-
-        /// <summary>
         /// The full path to the application's main executable.
         /// </summary>
         public static String exeString = System.Reflection.Assembly.GetExecutingAssembly().Location;
 
         public static String exeFolder = AppDomain.CurrentDomain.BaseDirectory;
+
+        /// <summary>
+        /// The folder in which the main executable resides.
+        /// </summary>
+        public static String path = System.IO.Path.GetDirectoryName(exeString);
 
         public static String defaultConfigPath;
         public static String defaultShortcutsPath;

--- a/main/Classes/Settings.cs
+++ b/main/Classes/Settings.cs
@@ -29,6 +29,7 @@ namespace client.Classes
             }
             else
             {
+                Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appDataRelative));
                 settingInfo = new Setting();
                 writeXML();
                 return;

--- a/main/Forms/frmGroup.cs
+++ b/main/Forms/frmGroup.cs
@@ -515,9 +515,9 @@ namespace client.Forms
         // Exit editor
         private void cmdExit_Click(object sender, EventArgs e)
         {
-            this.Hide();
-            this.Dispose();
+            this.Close();
             Client.Reload(); //flush and reload category panels
+            Client.Reset();
         }
 
         // Save group


### PR DESCRIPTION
Changes:
- Compile backgroundClient.exe to Resources folder. I think this is the most useful way to compile it because other way any time you compile it you have to manually copy to Resources folder in order to not have an obsolete version.
- Fixed a bug that caused that the program couldn't start the first time because the settings folder doesn't exists. First create settings folder if it doesn't exists and then create settings file.
- Fixed error "This program does not have access to this directory". 
- Fixed a bug that caused groups to not open. Should fix #9 . Maybe #17 too? I've added a try-catch to jumplist that seems it was the cause of the bug. I think that the cause is having recent items history disabled, and so jumplist failed to get written. Added a try-catch to avoid this.
- Fixed a bug that caused Alt+Enter shortcut to open all programs not work even if it was enabled.
- Fixed a bug that caused that group opacity setting was not working.
- Fixed a bug that caused that after exiting a group you won't be able to edit it again until next restart of the client.

I didn't include the compiled .exe because for security reasons I think the only one who has to include it it's the repositor owner. Also, I would like feedback from this since other users didn't have any of these bugs, so while they fixed for me I want to know if this brokes any feature to others users.